### PR TITLE
Correct serializer class name.

### DIFF
--- a/net/samples/FileEncryptionDecryption_ParquetFile/Program.cs
+++ b/net/samples/FileEncryptionDecryption_ParquetFile/Program.cs
@@ -43,7 +43,7 @@ namespace FileEncryptionDecryption_ParquetFile {
 
             // Modify a few column settings
             writerSettings[0] = new FileEncryptionSettings<DateTimeOffset?> (encryptionKey, SqlSerializerFactory.Default.GetDefaultSerializer<DateTimeOffset?> ());
-            writerSettings[3] = new FileEncryptionSettings<string> (encryptionKey, EncryptionType.Deterministic, new SqlVarcharSerializer (size: 255));
+            writerSettings[3] = new FileEncryptionSettings<string> (encryptionKey, EncryptionType.Deterministic, new SqlVarCharSerializer (size: 255));
             writerSettings[10] = new FileEncryptionSettings<double?> (encryptionKey, StandardSerializerFactory.Default.GetDefaultSerializer<double?> ());
 
             // Create and pass the target settings to the writer


### PR DESCRIPTION
In one of the sample files, the serializer class name had a typo. This caused a compilation error and undesirable red squiggles.
![image](https://user-images.githubusercontent.com/4079568/112329732-ad81ec00-8c74-11eb-8892-2655380747f7.png)
This change corrects the class name and fixes the error.
![image](https://user-images.githubusercontent.com/4079568/112330394-3bf66d80-8c75-11eb-932f-6f073ae07a93.png)
